### PR TITLE
Fix #27. Make the hamburger menu visible. Make the click area wider.

### DIFF
--- a/_includes/css/style.css
+++ b/_includes/css/style.css
@@ -131,6 +131,28 @@ a:focus {
 	border-color: transparent;
 }
 
+.navbar-toggle {
+	border: none;
+	margin: 0;
+	padding: 18px 26px 18px 11px;
+}
+
+.navbar-toggle .icon-bar {
+	background-color: {{ site.colors.link }};
+    -webkit-transition: background-color .4s linear;
+    -o-transition: background-color .4s linear;
+    transition: background-color .4s linear;
+}
+
+.navbar-toggle:hover .icon-bar,
+.navbar-toggle:focus .icon-bar {
+	background-color: {{ site.colors.link_hover }};
+}
+
+.navbar-toggle .icon-bar + .icon-bar {
+	margin-top: 6px;
+}
+
 .dropdown-menu {
 	background: {{ site.colors.secondary }};
 }


### PR DESCRIPTION
Hello!

At the moment, the collapse button is not visible, because both the border and the strips of the hamburger are transparent. To show the button, I repainted the hamburger in the color `{{ site.colors.link }}`. On hover I repaint them in `{{ site.colors.link_hover }}`. 

The `transition` property is also set as for links. Additional prefixes are verified using https://autoprefixer.github.io/

To make the button different from Bootstrap, I did not show the border around it, but instead slightly pushed the strips of the hamburger apart.

![navbar-toggle-off](https://user-images.githubusercontent.com/3881568/66176592-a3be9000-e65e-11e9-9b98-f781a866352e.png)

![navbar-toggle-on](https://user-images.githubusercontent.com/3881568/66176596-a6b98080-e65e-11e9-9a91-d56eb739304e.png)

To make the button easier to click, I increased the paddings by the width of the margins and the border, and removed the margins and the border themselves. Outwardly, nothing has changed, but the click area has become wider.

Before:...... ![clickarea-before](https://user-images.githubusercontent.com/3881568/66176554-77a30f00-e65e-11e9-9709-c7739ecd79c5.png)
After: ![clickarea-after](https://user-images.githubusercontent.com/3881568/66176558-7a9dff80-e65e-11e9-8c85-019fc274319e.png)

I would be glad if my code is useful.